### PR TITLE
Grammar tweak

### DIFF
--- a/gatsby/flavourText.js
+++ b/gatsby/flavourText.js
@@ -15,7 +15,7 @@ module.exports = [
   'has a Raspberry Pi',
   'is afraid of dogs',
   'hates TV',
-  'dank memes (and code)',
+  'likes dank memes (and code)',
   'likes vaporwave',
   'does React',
   'does TypeScript',


### PR DESCRIPTION
I'm not sure if "resir014 dank memes (and code)" makes very much sense. On one hand, dank is not a verb. On the other, it could be considered that dank is rather a subtitle, in which case a colon would be necessary. e.g. "resir014: dank memes (and code)" 

The most likely reasoning is the abscene of the word "like". The late addition often word "code" [in parentheses] implies that you forgot to add something super obvious (in this case, coding is a prerequisite to the creation of your personal website)

A third option is removing this flavo[u]r text altogether. This is a circumstance which I have avoided, mainly because of the lack of familiarity of personality and tone. I would not want to dictate how others feel and think.

Anyway, let me know if this modification on line 18 is sufficient. A small change, but world-changing nonetheless.

<details>
<summary>TL;DR</summary>
this is a bunch of rubbish justifying this PR in a naive effort to fetch a free Hacktoberfest 2018 T-shirt
</details>